### PR TITLE
Implement delete_before_upload feature

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -104,3 +104,66 @@ jobs:
             exit 1
           fi
           echo -e "\e[32mCorrect files left on server.\e[0m"
+      - name: Create hardlinks to some of the previously uploaded files
+        run: |
+          set -e
+          ssh -o UserKnownHostsFile=~/.ssh/known_hosts.test -o "HostKeyAlgorithms=${{ steps.server.outputs.hostkey-algos }}" -i ~/.ssh/id_rsa.test -p 2222 test@127.0.0.1 "cd /test && cp -l 11 11-copy"
+      - name: Fill one of the files with new data
+        run: |
+          set -e
+          echo 'Test Data' >> testdata/11
+      - name: Re-upload the new file(s) without deleting the files with the same names
+        uses: ./
+        with:
+          host: 127.0.0.1
+          port: 2222
+          username: test
+          key: ${{ steps.ssh-key.outputs.private-key }}
+          source: testdata/11
+          target: /test
+          cleanup: yes
+          known_hosts: ${{ steps.server.outputs.hostkeys }}
+      - name: Test if the upload modified the previously hard-linked file(s)
+        run: |
+          set -e
+          SHA256SUM=$(ssh -o UserKnownHostsFile=~/.ssh/known_hosts.test -o "HostKeyAlgorithms=${{ steps.server.outputs.hostkey-algos }}" -i ~/.ssh/id_rsa.test -p 2222 test@127.0.0.1 "sha256sum /test/11 | cut -f1 -d' '")
+          if [ "${SHA256SUM}" != "15c94dc2cf2ff71f83d0e5b9f7e7c3eb5efa8ba215dca81108cabf91f1958834" ]; then
+            echo -e "\e[31mFile was not properly uploaded.\e[0m"
+            exit 1
+          fi
+
+          SHA256SUM=$(ssh -o UserKnownHostsFile=~/.ssh/known_hosts.test -o "HostKeyAlgorithms=${{ steps.server.outputs.hostkey-algos }}" -i ~/.ssh/id_rsa.test -p 2222 test@127.0.0.1 "sha256sum /test/11-copy | cut -f1 -d' '")
+          if [ "${SHA256SUM}" != "15c94dc2cf2ff71f83d0e5b9f7e7c3eb5efa8ba215dca81108cabf91f1958834" ]; then
+            echo -e "\e[31mPreviously uploaded file wasn't modified by the newly uploaded file.\e[0m"
+            exit 1
+          fi
+      - name: Fill one of the files with (yet more) new data
+        run: |
+          set -e
+          echo 'Test Data Test Data' >> testdata/11
+      - name: Re-upload the new file(s) deleting the files with the same names
+        uses: ./
+        with:
+          host: 127.0.0.1
+          port: 2222
+          username: test
+          key: ${{ steps.ssh-key.outputs.private-key }}
+          source: testdata/11
+          target: /test
+          delete_before_upload: yes
+          cleanup: yes
+          known_hosts: ${{ steps.server.outputs.hostkeys }}
+      - name: Test if the upload modified the previously hard-linked file(s)
+        run: |
+          set -e
+          SHA256SUM=$(ssh -o UserKnownHostsFile=~/.ssh/known_hosts.test -o "HostKeyAlgorithms=${{ steps.server.outputs.hostkey-algos }}" -i ~/.ssh/id_rsa.test -p 2222 test@127.0.0.1 "sha256sum /test/11 | cut -f1 -d' '")
+          if [ "${SHA256SUM}" != "10237c1e142ed418cddb16ec249c89df4ffd4a9a729fdc2a6b41c8aa41f6d027" ]; then
+            echo -e "\e[31mFile was not properly uploaded.\e[0m"
+            exit 1
+          fi
+
+          SHA256SUM=$(ssh -o UserKnownHostsFile=~/.ssh/known_hosts.test -o "HostKeyAlgorithms=${{ steps.server.outputs.hostkey-algos }}" -i ~/.ssh/id_rsa.test -p 2222 test@127.0.0.1 "sha256sum /test/11-copy | cut -f1 -d' '")
+          if [ "${SHA256SUM}" != "15c94dc2cf2ff71f83d0e5b9f7e7c3eb5efa8ba215dca81108cabf91f1958834" ]; then
+            echo -e "\e[31mPreviously uploaded file was modified by the newly uploaded file.\e[0m"
+            exit 1
+          fi

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -112,6 +112,10 @@ jobs:
         run: |
           set -e
           echo 'Test Data' >> testdata/11
+      - name: Clean the source directory a bit
+        run: |
+          set -e
+          rm testdata/10 testdata/12 testdata/13 testdata/15 testdata/17
       - name: Re-upload the new file(s) without deleting the files with the same names
         uses: ./
         with:
@@ -119,7 +123,7 @@ jobs:
           port: 2222
           username: test
           key: ${{ steps.ssh-key.outputs.private-key }}
-          source: testdata/11
+          source: testdata/1*
           target: /test
           cleanup: yes
           known_hosts: ${{ steps.server.outputs.hostkeys }}
@@ -148,7 +152,7 @@ jobs:
           port: 2222
           username: test
           key: ${{ steps.ssh-key.outputs.private-key }}
-          source: testdata/11
+          source: testdata/1*
           target: /test
           delete_before_upload: yes
           cleanup: yes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ jobs:
           target: /test
           # SSH hostname to upload to. Optional, defaults to resources.ovirt.org
           host: resources.ovirt.org 
+          # Delete the file(s) before uploading file(s) with the same name(s). Useful in case we hard-link the uploaded files.
+          delete_before_upload: no
           # Cleanup files on target server, keep the last few. Optional, defaults to "no".
           cleanup: yes
           # How many files to keep. Optional, defaults to 1000.
@@ -40,3 +42,9 @@ jobs:
 ## A note on cleanup
 
 The cleanup process deletes all but the last X files from the target server based on the *modification date*. However, the modification date is preserved during upload, so the deletion process may yield unexpected results. If you are uploading older files make sure to `touch` them before upload!
+
+
+## A note on delete_before_upload
+
+This option is useful when we hard-link the uploaded files i.e. to save disk space, and don't want the upload of the file with the exisiting file name to push changes to all the hard-linked files. Setting delete_before_upload to yes will attempt to delete file before uploading it, effectively implementing a Copy-On-Write approach in this case.
+Please note that if you use wildcards, then all files matching the wildcard in the target directory will be removed, not the files that match the wildcard in the source directory.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,3 @@ The cleanup process deletes all but the last X files from the target server base
 ## A note on delete_before_upload
 
 This option is useful when we hard-link the uploaded files i.e. to save disk space, and don't want the upload of the file with the exisiting file name to push changes to all the hard-linked files. Setting delete_before_upload to yes will attempt to delete file before uploading it, effectively implementing a Copy-On-Write approach in this case.
-Please note that if you use wildcards, then all files matching the wildcard in the target directory will be removed, not the files that match the wildcard in the source directory.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   target:
     description: 'Target directory on resources.ovirt.org.'
     required: false
+  delete_before_upload:
+    description: 'Delete files in the target with the same name(s) before the upload'
+    required: false
+    default: 'no'
   cleanup:
     description: 'Clean up files in target directory. Can be yes or no. If enabled it will remove all but the last 1000 files by file date from the specified directory.'
     required: false
@@ -48,6 +52,7 @@ runs:
         KEY: ${{ inputs.key }}
         SOURCE: ${{ inputs.source }}
         TARGET: ${{ inputs.target }}
+        DELETE_BEFORE_UPLOAD: ${{ inputs.delete_before_upload }}
         CLEANUP: ${{ inputs.cleanup }}
         KEEP_FILES_COUNT: ${{ inputs.keep_files_count }}
         PORT: ${{ inputs.port }}
@@ -81,6 +86,11 @@ runs:
         echo -e "\e[32mValidating source...\e[0m"
         if [ -z "$(ls ${SOURCE})" ]; then
           echo -e "\e[31mThe source you provided matches no files.\e[0m" >&2
+          exit 128
+        fi
+        echo -e "\e[32mValidating delete_before_upload...\e[0m"
+        if ! [[ "${DELETE_BEFORE_UPLOAD}" =~ ^(yes|no)$ ]]; then
+          echo -e "\e[31mThe value provided to 'delete_before_upload' is invalid, must be 'yes' or 'no'.\e[0m" >&2
           exit 128
         fi
         echo -e "\e[32mValidating cleanup...\e[0m"
@@ -139,6 +149,26 @@ runs:
         echo -n "${HOST_KEY_ALGOS//$'\n'/,}" >~/.ssh/host_key_types.sshupload
         echo "Common host key types:"
         cat ~/.ssh/host_key_types.sshupload
+    - name: "Delete files before upload"
+      env:
+        # We add the parameters as environment variables, so they can be properly quoted in the shell code below.
+        HOST: ${{ inputs.host }}
+        USERNAME: ${{ inputs.username }}
+        SOURCE: ${{ inputs.source }}
+        TARGET: ${{ inputs.target }}
+        DELETE_BEFORE_UPLOAD: ${{ inputs.delete_before_upload }}
+        PORT: ${{ inputs.port }}
+        KNOWN_HOSTS: ${{ inputs.known_hosts }}
+      if: inputs.delete_before_upload == 'yes'
+      shell: bash
+      run: |
+        set -e
+        echo -e "\e[32mDeleting files in the target before upload...\e[0m"
+        cat <<<"${KNOWN_HOSTS}" >~/.ssh/known_hosts.sshupload
+        SOURCE=$(basename "${SOURCE}")
+        COMMAND="set -e; cd '${TARGET}' && rm "${SOURCE}" || true"
+        echo "Running remote command: ${COMMAND}"
+        ssh -i ~/.ssh/id_rsa.sshupload -o UserKnownHostsFile=~/.ssh/known_hosts.sshupload -o "HostKeyAlgorithms=$(cat ~/.ssh/host_key_types.sshupload)" -o PreferredAuthentications=publickey -p "${PORT}" "${USERNAME}@${HOST}" "${COMMAND}"
     - name: "Upload files"
       env:
         # We add the parameters as environment variables, so they can be properly quoted in the shell code below.

--- a/action.yml
+++ b/action.yml
@@ -165,8 +165,10 @@ runs:
         set -e
         echo -e "\e[32mDeleting files in the target before upload...\e[0m"
         cat <<<"${KNOWN_HOSTS}" >~/.ssh/known_hosts.sshupload
-        SOURCE=$(basename "${SOURCE}")
-        COMMAND="set -e; cd '${TARGET}' && rm "${SOURCE}" || true"
+        echo "SOURCE is set to: ${SOURCE}"
+        FILES=$(echo $SOURCE)
+        echo "FILES is set to: ${FILES}"
+        COMMAND='set -e; cd '${TARGET}' && for file in '${FILES}'; do echo "file: $file" && rm -v $(basename $file) || true; done'
         echo "Running remote command: ${COMMAND}"
         ssh -i ~/.ssh/id_rsa.sshupload -o UserKnownHostsFile=~/.ssh/known_hosts.sshupload -o "HostKeyAlgorithms=$(cat ~/.ssh/host_key_types.sshupload)" -o PreferredAuthentications=publickey -p "${PORT}" "${USERNAME}@${HOST}" "${COMMAND}"
     - name: "Upload files"


### PR DESCRIPTION
In some cases it may be desirable to make sure that uploading always creates new files, even if the the file(s) with the same names already exist in the target directory.

Otherwise if somebody hard-links to the existing file, the upload using the same filename will modify all the hard-linked files, which may come as a surprise and undesired behavior.

When using the delete_before_upload option (specified and set to yes) we'll first attempt to delete the file in the target directory, and only then to upload it there. Thus implementing Copy-On-Write in case one hard-links to the uploaded files.